### PR TITLE
Adds Snapshot Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ Add the resource using the Juju resources feature:
 juju attach jenkins-workspace workspace=kubernetes-builder.tgz
 ```
 
+## Supported Actions
+
+Snapshot - Compress a workspace.tgz compatible with this charms resources.
+
+Example snapshot and restore operation:
+
+```
+juju run-action jenkins-workspace/0 snapshot outfile=/home/ubuntu/workspace.tgz
+juju scp jenkins-workspace/0:/home/ubuntu/workspaces.tgz .
+juju attach jenkins-workspace workspaces=./workspaces.tgz
+```
+
 # Further information
 
 This charm was built from a the 

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,7 @@
+snapshot:
+  description: Take a snapshot of the workspace
+  params:
+    outfile:
+      type: string
+      description: The full path for compressed output
+      default: /home/ubuntu/snapshot.tgz

--- a/actions/snapshot
+++ b/actions/snapshot
@@ -1,0 +1,18 @@
+#!/bin/bash
+status-set maintenance "Compressing active workspace configurations."
+FINAL_DESTINATION=$(action-get outfile)
+cd /var/lib/jenkins/jobs
+tar --exclude='*.tgz' --exclude='Makefile' -cvzf workspaces.tgz ./*/config.xml
+chown ubuntu:ubuntu workspaces.tgz
+SNAPSHOT_FINGERPRINT=$(sha256sum workspaces.tgz)
+if [ -z $FINAL_DESTINATION ]
+then
+  mv workspaces.tgz /home/ubuntu/workspaces.tgz
+  FINAL_DESTINATION="/home/ubuntu/workspaces.tgz"
+else
+  mv workspaces.tgz $FINAL_DESTINATION
+fi
+status-set active 
+action-set output.file="$FINAL_DESTINATION"
+action-set output.256sum="$SNAPSHOT_FINGERPRINT"
+action-set fetch.cmd="juju scp $JUJU_UNIT_NAME:$FINAL_DESTINATION ."


### PR DESCRIPTION
This action allows the operator to create a configuration snapshot of
their running CI services. This can then be re-used as a resource for
the workspace in this charm.

Combine this with a well-formed list of jenkins plugins that you've
consumed in your jenkins charm.

*ProTip :

> juju set-config jenkins remove-unlisted-plugins=yes
> This will effectively prevent your CI server from drifting from
> plugins that juju is aware of. This enforces good behavior.
